### PR TITLE
Made data dir configurable (UUID use case didn't work for me)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .venv
 data/*.pdf
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![smithery badge](https://smithery.ai/badge/@danielkennedy1/pdf-tools-mcp)](https://smithery.ai/server/@danielkennedy1/pdf-tools-mcp)
 
 A comprehensive set of PDF manipulation tools built with the Model Context Protocol (MCP) framework.
+This forked version of the original gets access to one data directory, similar to the Filesystem MCP, and can read and manipulate all files in there.
 
 ## Features
 
@@ -10,7 +11,7 @@ A comprehensive set of PDF manipulation tools built with the Model Context Proto
 - **Display**: Render PDF pages as images
 - **Merge**: Combine multiple pages into a single long page
 - **Metadata**: Extract document metadata
-- **Text**: Extract text blocks and detailed text information
+- **Text**: Extract text blocks and detailed text information, or even all text in a PDF
 - **Snippets**: Create freeform or full-width snippets from PDF pages
 - **Fuse**: Combine pages from multiple documents into a single document
 
@@ -35,6 +36,8 @@ git clone https://github.com/yourusername/pdf-tools-mcp.git
 cd pdf-tools-mcp
 
 # Install dependencies
+uv venv
+source .venv/bin/activate
 uv pip install -e .
 ```
 
@@ -43,7 +46,16 @@ uv pip install -e .
 Start the MCP server:
 
 ```bash
-python -m src.main
+startServer.sh --data-dir /Users/me/Agents/files
+```
+
+Configuration for Claude Desktop:
+```claude_desktop_config.json
+    "pdf-tools-mcp": {
+      "command": "/Users/me/Agents/servers/pdf-tools-mcp/startServer.sh",
+      "args": ["--data-dir", "/Users/me/Agents/files"],
+      "cwd": "/Users/me/Agents/servers/pdf-tools-mcp"
+    } 
 ```
 
 The server provides PDF manipulation endpoints through the MCP protocol.
@@ -52,7 +64,6 @@ The server provides PDF manipulation endpoints through the MCP protocol.
 
 - Python 3.12+ required
 - Uses the MCP framework for tool registration
-- PDF documents are stored with UUID4 filenames for security
 
 ```bash
 # Update dependencies

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,5 @@
 import re
 
-DATA_DIR = "data"
-
 allowed_prefixes = [
     "merged_",
     "snippet_",
@@ -9,4 +7,4 @@ allowed_prefixes = [
 ]
 # Join the prefixes with | for alternation and make the entire group optional
 prefix_pattern = f"(?:{'|'.join(re.escape(prefix) for prefix in allowed_prefixes)})?"
-uuid4_pdf_re = re.compile(f"^{prefix_pattern}[0-9a-f]{{8}}-[0-9a-f]{{4}}-4[0-9a-f]{{3}}-[89ab][0-9a-f]{{3}}-[0-9a-f]{{12}}\\.pdf$")
+uuid4_pdf_re = re.compile(r".*(\.pdf|\.PDF)$")

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1,0 +1,5 @@
+class ConfigManager:
+    def __init__(self):
+        self.data_dir = "data"
+
+config_manager = ConfigManager()

--- a/src/local/display.py
+++ b/src/local/display.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import fitz
 from mcp.server.fastmcp.utilities.types import Image
 
-from config import DATA_DIR, uuid4_pdf_re
+from config import uuid4_pdf_re
+from config_manager import config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -14,10 +15,10 @@ async def display_page_as_image(name: str, page_number: int = 1):
     """
 
     if not uuid4_pdf_re.match(name):
-        logger.error("Input file must be in the 'data' folder and have a .pdf extension.")
+        logger.error(f"Input file '{name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
         return False
 
-    path = Path(DATA_DIR, name)
+    path = Path(config_manager.data_dir, name)
 
     logger.info(f"Displaying page {page_number} from path {path}")
     try:

--- a/src/local/fuse.py
+++ b/src/local/fuse.py
@@ -4,7 +4,8 @@ import uuid
 import logging
 from pathlib import Path
 
-from config import DATA_DIR, uuid4_pdf_re
+from config import uuid4_pdf_re
+from config_manager import config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +26,10 @@ async def fuse_documents(document_names: List[str], page_numbers: List[int]):
     pages = []
 
     for doc_name, page_num in zip(document_names, page_numbers):
-        doc = fitz.open(Path(DATA_DIR, doc_name))
+        if not uuid4_pdf_re.match(doc_name):
+            logger.error(f"Input file '{doc_name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
+            return False
+        doc = fitz.open(Path(config_manager.data_dir, doc_name))
         
         pages.append(doc[page_num - 1])
 
@@ -43,7 +47,7 @@ async def fuse_documents(document_names: List[str], page_numbers: List[int]):
     
     fused_doc_name = f"fused_{uuid.uuid4()}.pdf"
 
-    fused_document.save(Path(DATA_DIR, fused_doc_name))
+    fused_document.save(Path(config_manager.data_dir, fused_doc_name))
 
     fused_document.close()
 

--- a/src/local/merge.py
+++ b/src/local/merge.py
@@ -2,7 +2,8 @@ import fitz
 import logging
 from pathlib import Path
 
-from config import uuid4_pdf_re, DATA_DIR
+from config import uuid4_pdf_re
+from config_manager import config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -12,10 +13,10 @@ def merge_pages(input_file_name: str):
     """
 
     if not uuid4_pdf_re.match(input_file_name):
-        logger.error("Input file must be in the 'data' folder and have a .pdf extension.")
+        logger.error(f"Input file '{input_file_name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
         return False
 
-    input_file = Path(DATA_DIR, input_file_name)
+    input_file = Path(config_manager.data_dir, input_file_name)
 
     src = fitz.open(input_file.as_posix())
     doc = fitz.open()

--- a/src/local/metadata.py
+++ b/src/local/metadata.py
@@ -2,7 +2,8 @@ import fitz
 import logging
 from pathlib import Path
 
-from config import DATA_DIR, uuid4_pdf_re
+from config import uuid4_pdf_re
+from config_manager import config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -13,10 +14,10 @@ async def get_metadata(file_name: str):
     """
 
     if not uuid4_pdf_re.match(file_name):
-        logger.error("Input file must be in the 'data' folder and have a .pdf extension.")
+        logger.error(f"Input file '{file_name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
         return False
 
-    file_path = Path(DATA_DIR, file_name)
+    file_path = Path(config_manager.data_dir, file_name)
 
 
     # Initialize result dictionary

--- a/src/local/snippet.py
+++ b/src/local/snippet.py
@@ -4,7 +4,8 @@ from pathlib import Path
 from typing import Tuple
 import uuid
 
-from config import DATA_DIR, uuid4_pdf_re
+from config import uuid4_pdf_re
+from config_manager import config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +28,10 @@ async def create_free_snippet(file_name: str, clip_rect: Tuple[float, float, flo
     """
 
     if not uuid4_pdf_re.match(file_name):
-        logger.error(
-            "Input file must be in the 'data' folder and have a .pdf extension."
-        )
+        logger.error(f"Input file '{file_name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
         return False
 
-    file_path = Path(DATA_DIR, file_name)
+    file_path = Path(config_manager.data_dir, file_name)
 
     document = fitz.open(file_path)
 
@@ -49,7 +48,7 @@ async def create_free_snippet(file_name: str, clip_rect: Tuple[float, float, flo
 
     snippet_file_name = f"snippet_{snippet_uuid}.pdf"
 
-    snippet_file_path = Path(DATA_DIR, snippet_file_name)
+    snippet_file_path = Path(config_manager.data_dir, snippet_file_name)
 
     snippet = create_snippet(page, fitz.Rect(clip_rect))
 
@@ -72,12 +71,10 @@ async def create_full_width_snippet(file_name: str, clip_rect: Tuple[float, floa
     """
 
     if not uuid4_pdf_re.match(file_name):
-        logger.error(
-            "Input file must be in the 'data' folder and have a .pdf extension."
-        )
+        logger.error(f"Input file '{file_name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
         return False
 
-    file_path = Path(DATA_DIR, file_name)
+    file_path = Path(config_manager.data_dir, file_name)
 
     document = fitz.open(file_path)
 
@@ -94,7 +91,7 @@ async def create_full_width_snippet(file_name: str, clip_rect: Tuple[float, floa
 
     snippet_file_name = f"snippet_{snippet_uuid}.pdf"
 
-    snippet_file_path = Path(DATA_DIR, snippet_file_name)
+    snippet_file_path = Path(config_manager.data_dir, snippet_file_name)
 
     snippet = create_snippet(page, fitz.Rect(0, clip_rect[0], page.bound().width, clip_rect[1]))
 

--- a/src/local/text.py
+++ b/src/local/text.py
@@ -3,7 +3,8 @@ import logging
 from pathlib import Path
 import json
 
-from config import DATA_DIR, uuid4_pdf_re
+from config import uuid4_pdf_re
+from config_manager import config_manager
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +15,10 @@ async def get_text_blocks(file_name: str, page_number: int = 1):
     """
 
     if not uuid4_pdf_re.match(file_name):
-        logger.error(
-            "Input file must be in the 'data' folder and have a .pdf extension."
-        )
+        logger.error(f"Input file '{file_name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
         return False
 
-    file_path = Path(DATA_DIR, file_name)
+    file_path = Path(config_manager.data_dir, file_name)
 
     document = fitz.open(file_path)
 
@@ -57,12 +56,10 @@ async def get_text_json(file_name: str, page_number: int = 1):
     """
 
     if not uuid4_pdf_re.match(file_name):
-        logger.error(
-            "Input file must be in the 'data' folder and have a .pdf extension."
-        )
+        logger.error(f"Input file '{file_name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
         return False
 
-    file_path = Path(DATA_DIR, file_name)
+    file_path = Path(config_manager.data_dir, file_name)
 
     document = fitz.open(file_path)
 
@@ -82,5 +79,33 @@ async def get_text_json(file_name: str, page_number: int = 1):
     }
 
     logger.info("Returning response of length: %s", len(str(result)))
+
+    return response
+
+async def get_text(file_name: str):
+    """
+    Extract all text content from a PDF file.
+    """
+
+    if not uuid4_pdf_re.match(file_name):
+        logger.error(f"Input file '{file_name}' must be in the '{config_manager.data_dir}' folder and have a .pdf or .PDF extension.")
+        return False
+
+    file_path = Path(config_manager.data_dir, file_name)
+
+    document = fitz.open(file_path)
+
+    full_text = ""
+    for page_num in range(len(document)):
+        page = document[page_num]
+        full_text += page.get_text()
+
+    response = {
+        "success": True,
+        "file_name": file_name,
+        "text": full_text,
+    }
+
+    logger.info("Returning response of length: %s", len(str(response)))
 
     return response

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,14 @@
 import logging
+import argparse
 
 from mcp.server.fastmcp import FastMCP
+
+from config_manager import config_manager
 
 from local.display import display_page_as_image
 from local.merge import merge_pages
 from local.metadata import get_metadata
-from local.text import get_text_blocks, get_text_json
+from local.text import get_text_blocks, get_text_json, get_text
 from local.snippet import create_free_snippet, create_full_width_snippet
 from local.fuse import fuse_documents
 
@@ -15,21 +18,30 @@ from remote.download import download_pdf
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP("pdf-tools")
 
-mcp.add_tool(display_page_as_image)
-mcp.add_tool(merge_pages)
-mcp.add_tool(get_metadata)
-mcp.add_tool(get_text_blocks)
-mcp.add_tool(get_text_json)
-mcp.add_tool(create_free_snippet)
-mcp.add_tool(create_full_width_snippet)
-mcp.add_tool(fuse_documents)
-
-mcp.add_tool(display_remote_document_page_as_image)
-mcp.add_tool(download_pdf)
 
 def main():
+    parser = argparse.ArgumentParser(description="PDF Tools MCP")
+    parser.add_argument("--data-dir", type=str, default="data", help="Directory where PDF files are stored.")
+    args = parser.parse_args()
+
+    config_manager.data_dir = args.data_dir
+    
+    mcp = FastMCP("pdf-tools", data_dir=args.data_dir)
+
+    mcp.add_tool(display_page_as_image)
+    mcp.add_tool(merge_pages)
+    mcp.add_tool(get_metadata)
+    mcp.add_tool(get_text_blocks)
+    mcp.add_tool(get_text_json)
+    mcp.add_tool(get_text)
+    mcp.add_tool(create_free_snippet)
+    mcp.add_tool(create_full_width_snippet)
+    mcp.add_tool(fuse_documents)
+
+    mcp.add_tool(display_remote_document_page_as_image)
+    mcp.add_tool(download_pdf)
+
     try:
         mcp.run()
     except Exception as e:

--- a/src/remote/download.py
+++ b/src/remote/download.py
@@ -3,7 +3,7 @@ import aiofiles
 import os
 import uuid
 
-from config import DATA_DIR
+from config_manager import config_manager
 
 async def download_pdf(url):
     """
@@ -12,7 +12,7 @@ async def download_pdf(url):
 
     file_name = uuid.uuid4()
 
-    save_path = os.path.join(os.getcwd(), DATA_DIR, f"{file_name}.pdf")
+    save_path = os.path.join(os.getcwd(), config_manager.data_dir, f"{file_name}.pdf")
 
     try:
         # Make an asynchronous request to the URL

--- a/startServer.sh
+++ b/startServer.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Change to the directory where the script is located
+cd "$(dirname "$0")"
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Pass all arguments to the python script
+python -m src.main "$@"


### PR DESCRIPTION
I made some changes that you may not agree with, because you probably put them there for a reason.

I was looking for a PDF MCP server so Claude and agents can read the contents of a bunch of PDFs in a directory. The existing implementation that restricted access by prefixes, UUIDs and a hardcoded directory didn't work for me. Again, you probably put it there for a reason, but I just didn't need that (and, honestly, I didn't understand it either).

I haven't needed the manipulation tools yet, so haven't tested if my changes work with them.